### PR TITLE
Added mcrcon terminal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.pyc
 *dist/
 *.egg-info/
+.vscode

--- a/README.rst
+++ b/README.rst
@@ -36,3 +36,25 @@ manually, and ideally disconnect::
     In [5]: resp = mcr.command("/whitelist add bob")
     In [6]: print(resp)
     In [7]: mcr.disconnect()
+
+Command Line Usage
+##################
+
+You can connect from the console with commands like the following::
+
+    python -m mcrcon 10.1.1.1 sekret
+
+The output from `python -m mcrcon --help` is provided here::
+
+    usage: mcrcon.py [-h] [-p PORT] [-t] HOST PASSWORD
+    
+    connect to and use Minecraft Server remote console protocol
+    
+    positional arguments:
+      HOST                  the host to connect to
+      PASSWORD              the password to connect with
+    
+    optional arguments:
+      -h, --help            show this help message and exit
+      -p PORT, --port PORT  the port to connect to
+      -t, --tls             connect to the server with tls encryption

--- a/mcrcon.py
+++ b/mcrcon.py
@@ -119,12 +119,23 @@ try:
         parser.add_argument('-t', '--tls', dest='tlsmode', action='store_true', help='connect to the server with tls encryption')
         args = parser.parse_args()
 
-        with MCRcon(args.host, args.password, args.port, args.tlsmode) as mcr:
-            while True:
-                cmd = input('> ')
-                if cmd == 'exit':
-                    break
-                else:
-                    resp = mcr.command(cmd)
-                    print(resp)
+        try:
+            with MCRcon(args.host, args.password, args.port, args.tlsmode) as mcr:
+                while True:
+                    cmd = input('> ')
+                    if cmd == 'exit':
+                        break
+                    else:
+                        try:
+                            resp = mcr.command(cmd)
+                            print(resp)
+                        except (ConnectionResetError, ConnectionAbortedError):
+                            print('The connection was terminated, the server may could have been stopped.')
+                            break
+                        if cmd == 'stop':
+                            break
+        except ConnectionRefusedError:
+            print('The connection could not be made as the server actively refused it.')
+        except ConnectionError as e:
+            print(e)
 except KeyboardInterrupt: pass

--- a/mcrcon.py
+++ b/mcrcon.py
@@ -108,3 +108,23 @@ class MCRcon(object):
         result = self._send(2, command)
         time.sleep(0.003) # MC-72390 workaround
         return result
+
+try:
+    if __name__ == '__main__':
+        import argparse
+        parser = argparse.ArgumentParser(description='connect to and use Minecraft Server remote console protocol')
+        parser.add_argument('host', metavar='HOST', help='the host to connect to')
+        parser.add_argument('password', metavar='PASSWORD', help='the password to connect with')
+        parser.add_argument('-p', '--port', metavar='PORT', dest='port', type=int, default=25575, help='the port to connect to')
+        parser.add_argument('-t', '--tls', dest='tlsmode', action='store_true', help='connect to the server with tls encryption')
+        args = parser.parse_args()
+
+        with MCRcon(args.host, args.password, args.port, args.tlsmode) as mcr:
+            while True:
+                cmd = input('> ')
+                if cmd == 'exit':
+                    break
+                else:
+                    resp = mcr.command(cmd)
+                    print(resp)
+except KeyboardInterrupt: pass


### PR DESCRIPTION
This allows you to connect to a Minecraft Server via rcon with a command like `python -m mcrcon 10.1.1.1 sekret`, and use a terminal.