### PR TITLE
Timeout

### DIFF
--- a/mcrcon.py
+++ b/mcrcon.py
@@ -7,6 +7,7 @@ import select
 import struct
 import time
 import platform
+
 if platform.system() != "Windows":
     import signal
 
@@ -43,7 +44,7 @@ class MCRcon(object):
 
     socket = None
 
-    def __init__(self, host, password, port=25575, tlsmode=0, timeout=2):
+    def __init__(self, host, password, port=25575, tlsmode=0, timeout=5):
         self.host = host
         self.password = password
         self.port = port

--- a/mcrcon.py
+++ b/mcrcon.py
@@ -6,7 +6,9 @@ import ssl
 import select
 import struct
 import time
-import signal
+import platform
+if platform.system() != "Windows":
+    import signal
 
 
 class MCRconException(Exception):
@@ -47,7 +49,8 @@ class MCRcon(object):
         self.port = port
         self.tlsmode = tlsmode
         self.timeout = timeout
-        signal.signal(signal.SIGALRM, timeout_handler)
+        if platform.system() != "Windows":
+            signal.signal(signal.SIGALRM, timeout_handler)
 
     def __enter__(self):
         self.connect()
@@ -79,11 +82,13 @@ class MCRcon(object):
             self.socket = None
 
     def _read(self, length):
-        signal.alarm(self.timeout)
+        if platform.system() != "Windows":
+            signal.alarm(self.timeout)
         data = b""
         while len(data) < length:
             data += self.socket.recv(length - len(data))
-        signal.alarm(0)
+        if platform.system() != "Windows":
+            signal.alarm(0)
         return data
 
     def _send(self, out_type, out_data):

--- a/mcrcon.py
+++ b/mcrcon.py
@@ -49,14 +49,12 @@ class MCRcon(object):
         self.timeout = timeout
         signal.signal(signal.SIGALRM, timeout_handler)
 
-
     def __enter__(self):
         self.connect()
         return self
 
     def __exit__(self, type, value, tb):
         self.disconnect()
-
 
     def connect(self):
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)


### PR DESCRIPTION
Hi, this pull request adds a timeout function, so if a server crashes before MCRcon closes the connection, the script now throws an exception instead of waiting forever. 
I know it's ugly. I've tried to use the included timeout function in sockets, but it just didn't work, python ignored my timeout and hang on the recv call in MCRcon._read. The sginal.alert method is not available on Windows, but on that platform a ConnectionResetError is raised anyway, so this infinite timeout seems like a unix exclusive issue. I don't have a Mac at hand to test compatibility.